### PR TITLE
Sweep: add unit tests for protocols did-resolver module (✓ Sandbox Passed)

### DIFF
--- a/packages/protocol/tests/did-resolver.spec.ts
+++ b/packages/protocol/tests/did-resolver.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import { resolveDid, isVerificationMethod } from '../src/did-resolver';
+import { DidDocument, VerificationMethod, DidService } from '@web5/dids';
+import sinon from 'sinon';
+
+describe('DID Resolver', () => {
+  describe('resolveDid', () => {
+    it('resolves a valid DID correctly', async () => {
+      const mockDid = 'did:example:123';
+      const mockDidDocument = { id: mockDid } as DidDocument;
+      const resolveStub = sinon.stub().resolves({ didResolutionMetadata: {}, didDocument: mockDidDocument });
+      sinon.replace(DidResolver, 'resolve', resolveStub);
+
+      const didDocument = await resolveDid(mockDid);
+      expect(didDocument).to.deep.equal(mockDidDocument);
+      sinon.restore();
+    });
+
+    it('throws an error for an invalid DID', async () => {
+      const mockDid = 'did:example:invalid';
+      const resolveStub = sinon.stub().resolves({ didResolutionMetadata: { error: 'invalidDid' }, didDocument: null });
+      sinon.replace(DidResolver, 'resolve', resolveStub);
+
+      try {
+        await resolveDid(mockDid);
+        expect.fail('Expected error was not thrown');
+      } catch (error) {
+        expect(error.message).to.equal(`Failed to resolve DID: ${mockDid}. Error: invalidDid`);
+      }
+      sinon.restore();
+    });
+
+    it('throws an error when didResolutionMetadata is missing', async () => {
+      const mockDid = 'did:example:missingMetadata';
+      const resolveStub = sinon.stub().resolves({ didResolutionMetadata: null, didDocument: {} as DidDocument });
+      sinon.replace(DidResolver, 'resolve', resolveStub);
+
+      try {
+        await resolveDid(mockDid);
+        expect.fail('Expected error was not thrown');
+      } catch (error) {
+        expect(error.message).to.equal(`Failed to resolve DID: ${mockDid}. Error: undefined`);
+      }
+      sinon.restore();
+    });
+  });
+
+  describe('isVerificationMethod', () => {
+    it('returns true for a VerificationMethod', () => {
+      const verificationMethod = {
+        id: 'did:example:123#keys-1',
+        type: 'RsaVerificationKey2018',
+        controller: 'did:example:123',
+        publicKeyPem: '-----BEGIN PUBLIC KEY-----...'
+      } as VerificationMethod;
+
+      expect(isVerificationMethod(verificationMethod)).to.be.true;
+    });
+
+    it('returns false for a DidDocument', () => {
+      const didDocument = { id: 'did:example:123' } as DidDocument;
+      expect(isVerificationMethod(didDocument)).to.be.false;
+    });
+
+    it('returns false for a DidService', () => {
+      const didService = {
+        id: 'did:example:123;example',
+        type: 'LinkedDomains',
+        serviceEndpoint: 'https://example.com/'
+      } as DidService;
+
+      expect(isVerificationMethod(didService)).to.be.false;
+    });
+
+    it('returns false for null', () => {
+      expect(isVerificationMethod(null)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
# Description
This pull request adds unit tests for the protocols did-resolver module.

# Summary
- Added unit tests for `did-resolver.spec.ts`
- Created tests for `resolveDid` and `isVerificationMethod` functions
- Tested resolving a valid DID, throwing errors for invalid DID and missing metadata
- Tested verification method for VerificationMethod, DidDocument, DidService, and null

Fixes #14.

---

<details>
<summary><b>🎉 Latest improvements to Sweep:</b></summary>
<ul>
<li>New <a href="https://progress.sweep.dev">dashboard</a> launched for real-time tracking of Sweep issues, covering all stages from search to coding.</li>
<li>Integration of OpenAI's latest Assistant API for more efficient and reliable code planning and editing, improving speed by 3x.</li>
<li>Use the <a href="https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github">GitHub issues extension</a> for creating Sweep issues directly from your editor.</li>
</ul>
</details>


---

### 💡 To get Sweep to edit this pull request, you can:
* Comment below, and Sweep can edit the entire PR
* Comment on a file, Sweep will only modify the commented file
* Edit the original issue to get Sweep to recreate the PR from scratch